### PR TITLE
add desktop to list of terms

### DIFF
--- a/01/vocabulary.txt
+++ b/01/vocabulary.txt
@@ -5,3 +5,4 @@ redaction
 metadata
 fork
 plus
+desktop


### PR DESCRIPTION
I accidentally deleted "plus" and that seems to have done something. But i put it back and added "desktop"